### PR TITLE
S2-458 Add protected routes option and fix MIN_SCOPE bug.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ or e.g.
 ```
 
 #### Define protected routes
-With the PROTECTED setting you can define routes that require certain scopes for access. A distinction can me made between HTTP methods. An exception is made for the OPTIONS method, which is always allowed.
+With the PROTECTED setting you can define routes that require certain scopes for access. A distinction can be made between HTTP methods. An exception is made for the OPTIONS method, which is always allowed.
 ```
 # Require 'employee' scope for access to /api/secure route
 'PROTECTED': [
@@ -77,7 +77,7 @@ With the PROTECTED setting you can define routes that require certain scopes for
   ('/private', ['POST', 'PUT', 'PATCH', 'DELETE'])
 ]
 ```
-**Note:** the FORCED_ANONYMOUS_ROUTES setting takes precedence over the routes defined in PROTECTED, so if a path starts with a route set in FORCED_ANONYMOUS_ROUTES, access will be granted, no matter what is defined in 'PROTECTED' and authorization will not be checked.
+**Note:** the FORCED_ANONYMOUS_ROUTES setting takes precedence over the routes defined in PROTECTED, so if a route in PROTECTED starts with a route set in FORCED_ANONYMOUS_ROUTES, this will lead to a ProtectedRouteConflictError
 
 #### A method to check for authorization is added to the request object
 It will add a callable `request.is_authorized_for(authz_level)`
@@ -85,8 +85,6 @@ that can tell you whether the current request is authorized for the given
 `authz_level`:
 
 ```
-import authorization_django
-
 if request.is_authorized_for('level_admin'):
   ...  # do admin things
 elif request.is_authorized_for('level_employee'):

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ your ``settings.py`` in the ``DATAPUNT_AUTHZ`` dictionary.
 | JWKS_URL | A url to a valid JWKS, to validate tokens | "" |
 | MIN_INTERVAL_KEYSET_UPDATE | Minimal interval in secs between two checks for keyset update | 30 |
 | MIN_SCOPE | Minimum needed scope(s) to view non-whitelisted urls | empty tuple |
-| FORCED_ANONYMOUS_ROUTES | Routes for which not to check for authorization| empty tuple |
+| FORCED_ANONYMOUS_ROUTES | Routes for which not to check for authorization (whitelist)| empty tuple |
+| PROTECTED | Routes which require scopes for access. Optionally with distinction of methods | empty list |
 | ALWAYS_OK | Disable any authorization checks, use only for local development| False |
 | ALLOWED_SIGNING_ALGORITHMS | List of allowed algorithms for signing web tokens | ['ES256', 'ES384', 'ES512', 'RS256', 'RS384', 'RS512']|
 

--- a/authorization_django/middleware.py
+++ b/authorization_django/middleware.py
@@ -176,9 +176,7 @@ def authorization_middleware(get_response):
     def method_is_protected(method, protected_methods):
         if method.upper() in protected_methods:
             return True
-        if '*' in protected_methods and method.upper() is not 'OPTIONS':
-            return True
-        return False
+        return '*' in protected_methods and method.upper() is not 'OPTIONS'
 
     def middleware(request):
         """ Parses the Authorization header, decodes and validates the JWT and

--- a/authorization_django/middleware.py
+++ b/authorization_django/middleware.py
@@ -173,7 +173,7 @@ def authorization_middleware(get_response):
         """
         return scope.upper().replace("_", "/")
 
-    def method_protected(method, protected_methods):
+    def method_is_protected(method, protected_methods):
         if method.upper() in protected_methods:
             return True
         if '*' in protected_methods and method.upper() is not 'OPTIONS':
@@ -226,9 +226,9 @@ def authorization_middleware(get_response):
         for resource in PROTECTED:
             (route, protected_methods, required_scopes) = resource
             if request.path.startswith(route) and \
-                method_protected(request.method, protected_methods):
-                if not authz_func(*required_scopes):
-                    return insufficient_scope()
+                method_is_protected(request.method, protected_methods) and \
+                not authz_func(*required_scopes):
+                return insufficient_scope()
 
         request.is_authorized_for = authz_func
         request.get_token_subject = subject

--- a/authorization_django/middleware.py
+++ b/authorization_django/middleware.py
@@ -173,6 +173,13 @@ def authorization_middleware(get_response):
         """
         return scope.upper().replace("_", "/")
 
+    def method_protected(method, protected_methods):
+        if method.upper() in protected_methods:
+            return True
+        if '*' in protected_methods and method.upper() is not 'OPTIONS':
+            return True
+        return False
+
     def middleware(request):
         """ Parses the Authorization header, decodes and validates the JWT and
         adds the is_authorized_for function to the request.
@@ -212,8 +219,16 @@ def authorization_middleware(get_response):
         authz_func = authorize_function(scopes, token_signature, x_unique_id)
 
         min_scope = middleware_settings['MIN_SCOPE']
-        if len(min_scope) > 0 and not authz_func(min_scope):
+        if len(min_scope) > 0 and not authz_func(*min_scope):
             return insufficient_scope()
+
+        PROTECTED = middleware_settings['PROTECTED']
+        for resource in PROTECTED:
+            (route, protected_methods, required_scopes) = resource
+            if request.path.startswith(route) and \
+                method_protected(request.method, protected_methods):
+                if not authz_func(*required_scopes):
+                    return insufficient_scope()
 
         request.is_authorized_for = authz_func
         request.get_token_subject = subject

--- a/test_authorization_django.py
+++ b/test_authorization_django.py
@@ -443,21 +443,14 @@ def test_protected_resources_all_methods(tokendata_scope1, tokendata_two_scopes)
 
     # a token with scope1 gives access via all methods
     # to the one_scope_required route
-    request = create_request(
-       tokendata_scope1,
-       '4', 'Bearer', '/one_scope_required', 'GET'
-    )
-    response = middleware(request)
-    assert request.is_authorized_for('scope1')
-    assert response.status_code == 200
-
-    request = create_request(
-       tokendata_scope1,
-       '4', 'Bearer', '/one_scope_required', 'POST'
-    )
-    response = middleware(request)
-    assert request.is_authorized_for('scope1')
-    assert response.status_code == 200
+    for method in ('GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE'):
+        request = create_request(
+           tokendata_scope1,
+           '4', 'Bearer', '/one_scope_required', method
+        )
+        response = middleware(request)
+        assert request.is_authorized_for('scope1')
+        assert response.status_code == 200
 
     # a token with only scope1 does not give access to two_scopes_required route
     request = create_request(

--- a/test_authorization_django.py
+++ b/test_authorization_django.py
@@ -442,7 +442,7 @@ def test_protected_resources_all_methods(tokendata_scope1, tokendata_two_scopes)
     middleware = authorization_middleware(lambda r: ok_response)
 
     # a token with scope1 gives access via all methods
-    # to the one_scope_required path
+    # to the one_scope_required route
     request = create_request(
        tokendata_scope1,
        '4', 'Bearer', '/one_scope_required', 'GET'
@@ -459,7 +459,7 @@ def test_protected_resources_all_methods(tokendata_scope1, tokendata_two_scopes)
     assert request.is_authorized_for('scope1')
     assert response.status_code == 200
 
-    # a token with only scope1 does not give access to two_scopes_required path
+    # a token with only scope1 does not give access to two_scopes_required route
     request = create_request(
         tokendata_scope1,
         '4', 'Bearer', '/two_scopes_required', 'GET'
@@ -468,7 +468,7 @@ def test_protected_resources_all_methods(tokendata_scope1, tokendata_two_scopes)
     assert response.status_code == 401
     assert 'insufficient_scope' in response['WWW-Authenticate']
 
-    # a token with scope1 and scope2 gives access to two_scopes_required path
+    # a token with scope1 and scope2 gives access to two_scopes_required route
     request = create_request(
         tokendata_two_scopes,
         '4', 'Bearer', '/two_scopes_required', 'GET'


### PR DESCRIPTION
- Add configuration option PROTECTED to define which routes require which scopes.
- Fix bug that when MIN_SCOPE is configured as tuple (as documented), access is not granted even when required scope is in token.
- Extend unit tests