### PR TITLE
Expose scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ make test
 Changelog
 ---------
 - v1.1.0
+  * Expose scopes via get_token_scopes
+  * Fix SyntaxWarning in middleware
   * Add option to require authorization for specific routes
   * Fix MIN_SCOPE as tuple bug
 - v1.0.0

--- a/authorization_django/middleware.py
+++ b/authorization_django/middleware.py
@@ -176,7 +176,7 @@ def authorization_middleware(get_response):
     def method_is_protected(method, protected_methods):
         if method.upper() in protected_methods:
             return True
-        return '*' in protected_methods and method.upper() is not 'OPTIONS'
+        return '*' in protected_methods and method.upper() != 'OPTIONS'
 
     def middleware(request):
         """ Parses the Authorization header, decodes and validates the JWT and
@@ -230,6 +230,7 @@ def authorization_middleware(get_response):
 
         request.is_authorized_for = authz_func
         request.get_token_subject = subject
+        request.get_token_scopes = scopes
         return get_response(request)
 
     return middleware

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ class PyTest(TestCommand):
 with open('README.md', encoding='utf-8') as f:
     long_description = f.read()
 
-version = '1.0.0'
+version = '1.1.0'
 packages = ['authorization_django']
 requires = ['Django>=1.10.3', 'requests>=2.20.1', 'jwcrypto>=0.6.0']
 requires_test = ['pytest>=3.0.5', 'pytest-cov>=2.4.0', 'requests_mock']

--- a/test_authorization_django.py
+++ b/test_authorization_django.py
@@ -284,6 +284,12 @@ def test_get_token_subject(middleware, tokendata_two_scopes):
     assert request.get_token_subject == 'test@tester.nl'
 
 
+def test_get_token_scopes(middleware, tokendata_two_scopes):
+    request = create_request(tokendata_two_scopes, "4")
+    middleware(request)
+    assert request.get_token_scopes == ['scope1', 'scope2']
+
+
 def test_invalid_token_requests(
         middleware, tokendata_missing_scopes,
         tokendata_expired, tokendata_two_scopes):


### PR DESCRIPTION
We're extending audit logging and would need scopes to be logged separately from what middleware does.

Also fixed minor `SyntaxWarning` in middleware.