### PR TITLE
Expose claims for audit logging and another fallback for reading scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Changelog
 ---------
 - develop:
   * expose claims via get_token_claims
+  * read scopes from `resource_access` field if `realm_access` and
+    `scopes` fields do not exist
 - v1.1.0
   * Expose scopes via get_token_scopes
   * Fix SyntaxWarning in middleware

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ make test
 
 Changelog
 ---------
+- develop:
+  * expose claims via get_token_claims
 - v1.1.0
   * Expose scopes via get_token_scopes
   * Fix SyntaxWarning in middleware

--- a/README.md
+++ b/README.md
@@ -110,8 +110,6 @@ Changelog
 ---------
 - develop:
   * expose claims via get_token_claims
-  * read scopes from `resource_access` field if `realm_access` and
-    `scopes` fields do not exist
 - v1.1.0
   * Expose scopes via get_token_scopes
   * Fix SyntaxWarning in middleware

--- a/authorization_django/middleware.py
+++ b/authorization_django/middleware.py
@@ -24,7 +24,7 @@ def authorization_middleware(get_response):
     set an authorization function on the request.
 
     The decision to use a generic middleware rather than an
-    AuthenticationMiddleware is explicitly made, because instances of the
+    AuthenticationMiddleware is explicitly made, because inctances of the
     latter come with a number of assumptions (i.e. that user.is_authorized()
     exists, or that request.user uses the User model).
 
@@ -165,18 +165,6 @@ def authorization_middleware(get_response):
                 'sub': claims.get('sub'),
                 'scopes': {convert_scope(r) for r in claims['realm_access']['roles']},
                 'claims': claims
-            }
-        elif claims.get('resource_access'):
-            # resource structure used on Amsterdam production keycloak
-            resources = claims.get('resource_access')
-            scopes = set()
-            for res, specs in resources.items():
-                for role in specs.get('roles', []):
-                    scopes.add(convert_scope(f"{res}/{role}"))
-            return {
-                'sub': claims.get('sub'),
-                'scopes': scopes,
-                'claims': claims,
             }
         logger.warning(
             'API authz problem: access token misses scopes claim'

--- a/authorization_django/middleware.py
+++ b/authorization_django/middleware.py
@@ -24,7 +24,7 @@ def authorization_middleware(get_response):
     set an authorization function on the request.
 
     The decision to use a generic middleware rather than an
-    AuthenticationMiddleware is explicitly made, because inctances of the
+    AuthenticationMiddleware is explicitly made, because instances of the
     latter come with a number of assumptions (i.e. that user.is_authorized()
     exists, or that request.user uses the User model).
 
@@ -165,6 +165,18 @@ def authorization_middleware(get_response):
                 'sub': claims.get('sub'),
                 'scopes': {convert_scope(r) for r in claims['realm_access']['roles']},
                 'claims': claims
+            }
+        elif claims.get('resource_access'):
+            # resource structure used on Amsterdam production keycloak
+            resources = claims.get('resource_access')
+            scopes = set()
+            for res, specs in resources.items():
+                for role in specs.get('roles', []):
+                    scopes.add(convert_scope(f"{res}/{role}"))
+            return {
+                'sub': claims.get('sub'),
+                'scopes': scopes,
+                'claims': claims,
             }
         logger.warning(
             'API authz problem: access token misses scopes claim'

--- a/test_authorization_django.py
+++ b/test_authorization_django.py
@@ -151,21 +151,6 @@ def tokendata_scope2():
 
 
 @pytest.fixture
-def tokendata_with_resource_access():
-    now = int(time.time())
-    return {
-        'iat': now,
-        'exp': now + 30,
-        'scope': 'openid profile email',
-        'sub': 'a34a11b1-111a-1112-b112-111b111b1111',
-        'resource_access': {
-            'account': {'roles': ['view-profile']},
-            'test': {'roles': ['role1', 'role2']},
-        },
-    }
-
-
-@pytest.fixture
 def tokendata_two_scopes():
     now = int(time.time())
     return {
@@ -297,15 +282,6 @@ def test_get_token_subject(middleware, tokendata_two_scopes):
     request = create_request(tokendata_two_scopes, "4")
     middleware(request)
     assert request.get_token_subject == 'test@tester.nl'
-
-
-def test_get_token_scopes_from_resource_access(
-        middleware, tokendata_with_resource_access
-):
-    request = create_request(tokendata_with_resource_access, "4")
-    middleware(request)
-    expected = {'TEST/ROLE1', 'TEST/ROLE2', 'ACCOUNT/VIEW-PROFILE'}
-    assert request.get_token_scopes == expected
 
 
 def test_get_token_scopes(middleware, tokendata_two_scopes):

--- a/test_authorization_django.py
+++ b/test_authorization_django.py
@@ -151,6 +151,21 @@ def tokendata_scope2():
 
 
 @pytest.fixture
+def tokendata_with_resource_access():
+    now = int(time.time())
+    return {
+        'iat': now,
+        'exp': now + 30,
+        'scope': 'openid profile email',
+        'sub': 'a34a11b1-111a-1112-b112-111b111b1111',
+        'resource_access': {
+            'account': {'roles': ['view-profile']},
+            'test': {'roles': ['role1', 'role2']},
+        },
+    }
+
+
+@pytest.fixture
 def tokendata_two_scopes():
     now = int(time.time())
     return {
@@ -282,6 +297,15 @@ def test_get_token_subject(middleware, tokendata_two_scopes):
     request = create_request(tokendata_two_scopes, "4")
     middleware(request)
     assert request.get_token_subject == 'test@tester.nl'
+
+
+def test_get_token_scopes_from_resource_access(
+        middleware, tokendata_with_resource_access
+):
+    request = create_request(tokendata_with_resource_access, "4")
+    middleware(request)
+    expected = {'TEST/ROLE1', 'TEST/ROLE2', 'ACCOUNT/VIEW-PROFILE'}
+    assert request.get_token_scopes == expected
 
 
 def test_get_token_scopes(middleware, tokendata_two_scopes):

--- a/test_authorization_django.py
+++ b/test_authorization_django.py
@@ -290,6 +290,12 @@ def test_get_token_scopes(middleware, tokendata_two_scopes):
     assert request.get_token_scopes == ['scope1', 'scope2']
 
 
+def test_get_token_claims(middleware, tokendata_two_scopes):
+    request = create_request(tokendata_two_scopes, "4")
+    middleware(request)
+    assert request.get_token_claims == tokendata_two_scopes
+
+
 def test_invalid_token_requests(
         middleware, tokendata_missing_scopes,
         tokendata_expired, tokendata_two_scopes):


### PR DESCRIPTION
This PR contains ~~two~~ one change~~s~~:
1. expose the complete `claims` object, such that our application can get access to the user name and email (necessary for our audit logs)
~~2. read scopes from `resource_access` if the request contains neither `scopes` nor `realm_access`, using a similar logic as when reading from `realm_access`. This is necessary because the token that we can from the our production Keycloak does not contain scopes (well a `scope` field, but with no useful information~~