### PR TITLE
Adjust AD integration to represent new reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ make test
 
 Changelog
 ---------
+- v1.3.1
+  * Extended support for Microsoft Azure AD JWT Token structure
+  * Improved tests for Expired token logic
 - v1.3.0
   * Support Microsoft Azure AD JWT Token structure
 - v1.2.0:

--- a/authorization_django/middleware.py
+++ b/authorization_django/middleware.py
@@ -168,12 +168,9 @@ def authorization_middleware(get_response):
             }
         elif claims.get('groups') and (claims.get('unique_name') or claims.get('un')):
             # Azure AD token structure
-            scopes = set(
-                convert_scope(group.split('\\')[1]) for group in claims.get('groups')
-            )
             return {
                 'sub': claims.get('unique_name', claims.get('un')),
-                'scopes': scopes,
+                'scopes': {convert_scope(group.split(" ")[0]) for group in claims.get('groups')},
                 'claims': claims
             }
         logger.warning(

--- a/authorization_django/middleware.py
+++ b/authorization_django/middleware.py
@@ -79,7 +79,7 @@ def authorization_middleware(get_response):
         """ Returns an HttpResponse object with a 401
         """
         msg = 'Bearer realm="datapunt", error="expired_token"'
-        response = http.HttpResponse('Unauthorized. Token expired.', status=401)
+        response = http.HttpResponse('Unauthorized', status=401)
         response['WWW-Authenticate'] = msg
         return response
 
@@ -140,7 +140,7 @@ def authorization_middleware(get_response):
             logger.info(
                 'API authz problem: token expired {}'.format(raw_jwt)
             )
-            raise _AuthorizationHeaderError(expired_token())
+            raise _AuthorizationHeaderError(invalid_token())
         except InvalidJWSSignature as e:
             logger.warning('API authz problem: invalid signature. {}'.format(e))
             raise _AuthorizationHeaderError(invalid_token())

--- a/authorization_django/middleware.py
+++ b/authorization_django/middleware.py
@@ -166,13 +166,13 @@ def authorization_middleware(get_response):
                 'scopes': {convert_scope(r) for r in claims['realm_access']['roles']},
                 'claims': claims
             }
-        elif claims.get('groups') and claims.get('unique_name'):
+        elif claims.get('groups') and (claims.get('unique_name') or claims.get('un')):
             # Azure AD token structure
             scopes = set(
                 convert_scope(group.split('\\')[1]) for group in claims.get('groups')
             )
             return {
-                'sub': claims.get('unique_name'),
+                'sub': claims.get('unique_name', claims.get('un')),
                 'scopes': scopes,
                 'claims': claims
             }

--- a/authorization_django/middleware.py
+++ b/authorization_django/middleware.py
@@ -166,11 +166,14 @@ def authorization_middleware(get_response):
                 'scopes': {convert_scope(r) for r in claims['realm_access']['roles']},
                 'claims': claims
             }
-        elif claims.get('scp') and claims.get('preferred_username'):
-            # Microsoft token structure
+        elif claims.get('groups') and claims.get('unique_name'):
+            # Azure AD token structure
+            scopes = set(
+                convert_scope(group.split('\\')[1]) for group in claims.get('groups')
+            )
             return {
-                'sub': claims.get('preferred_username'),
-                'scopes': {convert_scope(r) for r in claims.get('scp').split(',')},
+                'sub': claims.get('unique_name'),
+                'scopes': scopes,
                 'claims': claims
             }
         logger.warning(

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ class PyTest(TestCommand):
 with open('README.md', encoding='utf-8') as f:
     long_description = f.read()
 
-version = '1.3.0'
+version = '1.3.1'
 packages = ['authorization_django']
 requires = ['Django>=1.10.3', 'requests>=2.20.1', 'jwcrypto>=0.6.0']
 requires_test = ['pytest>=3.0.5', 'pytest-cov>=2.4.0', 'requests_mock']

--- a/test_authorization_django.py
+++ b/test_authorization_django.py
@@ -125,8 +125,7 @@ def tokendata_missing_scopes():
 def tokendata_expired():
     now = int(time.time())
     return {
-        'iat': now - 1500,
-        'exp': now - 120
+        'exp': now - 5
     }
 
 
@@ -339,8 +338,10 @@ def test_get_token_claims(middleware, tokendata_two_scopes):
 
 
 def test_invalid_token_requests(
-        middleware, tokendata_missing_scopes, tokendata_two_scopes):
+        middleware, tokendata_missing_scopes,
+        tokendata_expired, tokendata_two_scopes):
     reqs = (
+        create_request(tokendata_expired, "4"),
         create_request(tokendata_missing_scopes, "5"),
         create_request(tokendata_two_scopes)  # unsigned token
     )

--- a/test_authorization_django.py
+++ b/test_authorization_django.py
@@ -108,6 +108,7 @@ def create_request(tokendata, kid=None, prefix='Bearer', path='/', method='GET')
         },
         path=path, method=method)
 
+
 def create_request_no_auth_header(path='/', method='GET'):
     return types.SimpleNamespace(META={}, path=path, method=method)
 
@@ -179,10 +180,9 @@ def tokendata_azure_ad_two_scopes():
     return {
         'iat': now,
         'exp': now + 30,
-        'scp': 'scope_1,scope_2',
-        'preferred_username': 'test@tester.nl',
+        'groups': ['test\\scope_1', 'test\\scope_2'],
+        'unique_name': 'test@tester.nl',
     }
-
 
 
 @pytest.fixture
@@ -197,8 +197,9 @@ def tokendata_keycloak_two_scopes():
 
 
 ok_response = types.SimpleNamespace(
-    status_code = 200
+    status_code=200
 )
+
 
 @pytest.fixture
 def middleware():
@@ -305,6 +306,7 @@ def test_azure_ad_token(middleware, tokendata_azure_ad_two_scopes):
     assert request.get_token_subject == "test@tester.nl"
     assert request.get_token_scopes == {"SCOPE/1", "SCOPE/2"}
 
+
 def test_valid_one_scope_request(middleware, tokendata_two_scopes):
     request = create_request(tokendata_two_scopes, "4")
     middleware(request)
@@ -336,7 +338,8 @@ def test_get_token_claims(middleware, tokendata_two_scopes):
     assert request.get_token_claims == tokendata_two_scopes
 
 
-def test_invalid_token_requests(middleware, tokendata_missing_scopes, tokendata_two_scopes):
+def test_invalid_token_requests(
+        middleware, tokendata_missing_scopes, tokendata_two_scopes):
     reqs = (
         create_request(tokendata_missing_scopes, "5"),
         create_request(tokendata_two_scopes)  # unsigned token


### PR DESCRIPTION
Looks like new Azure AD integration contains different set of parameters than before.
This PR adjusts our code to work with AzureAD as Identity Provider.

Also fixing minor issue with expired token errors.