### PR TITLE
Bump jwcrypto requirement to 1.4.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ with open('README.md', encoding='utf-8') as f:
 
 version = '1.3.2'
 packages = ['authorization_django']
-requires = ['Django>=1.10.3', 'requests>=2.20.1', 'jwcrypto>=0.6.0']
+requires = ['Django>=1.10.3', 'requests>=2.20.1', 'jwcrypto>=1.4.2']
 requires_test = ['pytest>=3.0.5', 'pytest-cov>=2.4.0', 'requests_mock']
 requires_extras = {
     'dev': [] + requires_test,

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ class PyTest(TestCommand):
 with open('README.md', encoding='utf-8') as f:
     long_description = f.read()
 
-version = '1.3.2'
+version = '1.3.3'
 packages = ['authorization_django']
 requires = ['Django>=1.10.3', 'requests>=2.20.1', 'jwcrypto>=1.4.2']
 requires_test = ['pytest>=3.0.5', 'pytest-cov>=2.4.0', 'requests_mock']


### PR DESCRIPTION
We've been running DSO-API with this new version for some time.