### PR TITLE
Fix Entra ID tokens for service principles

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ make test
 
 Changelog
 ---------
+- v1.6.1
+  * Catch Entra ID SPN tokens
 - v1.6.0
   * Added claim checking using `CHECK_CLAIMS`, and enforce it for Microsoft Entra ID.
 - v1.5.0

--- a/authorization_django/middleware.py
+++ b/authorization_django/middleware.py
@@ -180,10 +180,12 @@ class AuthorizationMiddleware:
                 "scopes": {self.convert_scope(r) for r in claims["realm_access"]["roles"]},
                 "claims": claims,
             }
-        elif claims.get("roles") and (claims.get("unique_name") or claims.get("upn")):
+        elif claims.get("roles") and (
+            claims.get("unique_name") or claims.get("upn") or claims.get("sub")
+        ):
             # Microsoft Entra ID token structure
             return {
-                "sub": claims.get("unique_name", claims.get("upn")),
+                "sub": claims.get("unique_name", claims.get("upn", claims.get("sub"))),
                 "scopes": set(claims["roles"]),
                 "claims": claims,
             }

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 with open("README.md", encoding="utf-8") as f:
     long_description = f.read()
 
-version = "1.6.0"
+version = "1.6.1"
 packages = [
     "authorization_django",
     "authorization_django.extensions",


### PR DESCRIPTION
Tokens created for service principles are missing the `unique_name` or `upn` claims, so we'll also catch the `sub`.