### PR TITLE
Allow both Entra and Keycloak to be configured at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ Changelog
 ---------
 - v1.8.0
   * Add support for apps that use both Entra ID and Keycloak
+- v1.7.0
+  * Support Python 3.13 and 3.14
 - v1.6.2
   * Add appid to Entra token claims
 - v1.6.1

--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ make test
 
 Changelog
 ---------
+- v1.8.0
+  * Add support for apps that use both Entra ID and Keycloak
 - v1.6.2
   * Add appid to Entra token claims
 - v1.6.1

--- a/authorization_django/config.py
+++ b/authorization_django/config.py
@@ -82,7 +82,6 @@ def load_settings():
     unknown = user_settings_keys - _available_settings_keys
     if unknown:
         raise AuthzConfigurationError(f"Unknown {_settings_key} config params: {unknown}")
-
     # Merge defaults with provided settings
     missing_defaults = _available_settings_keys - user_settings_keys
     user_settings.update({key: _available_settings[key] for key in missing_defaults})
@@ -92,9 +91,13 @@ def load_settings():
 
 
 def _validate_values(user_settings: dict):
-    if not user_settings["JWKS"] and not user_settings["JWKS_URL"]:
+    if (
+        not user_settings["JWKS"]
+        and not user_settings["JWKS_URL"]
+        and not user_settings["JWKS_URLS"]
+    ):
         raise AuthzConfigurationError(
-            f"Either {_settings_key}['JWKS'] or {_settings_key}['JWKS_URL'] must be set, or both"
+            f"{_settings_key}['JWKS'], {_settings_key}['JWKS_URL'] or {_settings_key}['JWKS_URLS']  must be set, or all"
         )
 
     is_entra = (

--- a/authorization_django/middleware.py
+++ b/authorization_django/middleware.py
@@ -141,14 +141,26 @@ class AuthorizationMiddleware:
 
     def _decode_token(self, raw_jwt):
         settings = get_settings()
-        keyset = get_keyset()  # does lazy loading here, inclusing fetching URLs
-
+        keyset = get_keyset()
         check_claims = settings["CHECK_CLAIMS"] or None
         if check_claims:
             # Specifying check_claims disables the automatic check on expiry,
             # so that needs to be explicitly added now.
             check_claims = {**check_claims, "exp": int(time())}
         try:
+            jwt = JWT(
+                jwt=raw_jwt,
+                key=keyset,
+                algs=settings["ALLOWED_SIGNING_ALGORITHMS"],
+            )
+
+            # Keycloak provides no aud claim
+            claims = json.loads(jwt.claims)
+            iss = claims.get("iss", None)
+            if check_claims and iss and iss.startswith("https://iam.amsterdam.nl"):
+                check_claims.pop("aud", None)
+                check_claims.pop("iss", None)
+
             jwt = JWT(
                 jwt=raw_jwt,
                 key=keyset,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 with open("README.md", encoding="utf-8") as f:
     long_description = f.read()
 
-version = "1.7.0"
+version = "1.8.0"
 packages = [
     "authorization_django",
     "authorization_django.extensions",

--- a/tests/test_authorization_django.py
+++ b/tests/test_authorization_django.py
@@ -12,7 +12,6 @@ from django import conf
 from django.http import HttpResponse
 from django.test import RequestFactory
 from jwcrypto.jwt import JWT
-from jwcrypto.common import JWException
 
 from authorization_django import authorization_middleware, config, jwks
 

--- a/tests/test_authorization_django.py
+++ b/tests/test_authorization_django.py
@@ -12,6 +12,7 @@ from django import conf
 from django.http import HttpResponse
 from django.test import RequestFactory
 from jwcrypto.jwt import JWT
+from jwcrypto.common import JWException
 
 from authorization_django import authorization_middleware, config, jwks
 
@@ -72,6 +73,7 @@ JWKS2 = {
         }
     ]
 }
+
 
 ALG_LOOKUP = {
     "1": "HS256",
@@ -186,6 +188,19 @@ def tokendata_two_scopes():
 
 
 @pytest.fixture
+def tokendata_two_scopes_aud_iss():
+    now = int(time.time())
+    return {
+        "iat": now,
+        "exp": now + 30,
+        "scopes": ["scope1", "scope2"],
+        "sub": "test@tester.nl",
+        "aud": "aud",
+        "iss": "iss",
+    }
+
+
+@pytest.fixture
 def tokendata_zero_scopes():
     now = int(time.time())
     return {
@@ -213,6 +228,8 @@ def tokendata_entra_id_two_scopes():
     return {
         "iat": now,
         "exp": now + 30,
+        "aud": "aud",
+        "iss": "https://sts.windows.net",
         "roles": ["test-scope-1", "test-scope-2"],
         "unique_name": "test@tester.nl",
         "appid": "client_id",
@@ -225,6 +242,7 @@ def tokendata_keycloak_two_scopes():
     return {
         "iat": now,
         "exp": now + 30,
+        "iss": "https://iam.amsterdam.nl",
         "realm_access": {"roles": ["scope_1", "scope_2"]},
         "sub": "test@tester.nl",
     }
@@ -284,6 +302,54 @@ def test_jwks_from_url(requests_mock, tokendata_two_scopes):
     reload_settings({"JWKS": None, "JWKS_URL": jwks_url})
     middleware = authorization_middleware(_ok_view)
     request = create_request(tokendata_two_scopes, "4")
+    middleware(request)
+    assert request.is_authorized_for("scope1", "scope2")
+
+
+def test_jwks_from_url_entra_success(requests_mock, tokendata_two_scopes_aud_iss):
+    """Verify that loading keyset from entra url works,
+    by checking that aud and iss claims are present
+    and is_authorized_for method correctly evaluates
+    that user has the scopes mentioned in the token data
+    """
+    jwks_url = "https://login.microsoftonline.com/get.your.jwks.here/discovery/keys"
+    requests_mock.get(jwks_url, text=json.dumps(JWKS1))
+    reload_settings(
+        {"JWKS": None, "JWKS_URL": jwks_url, "CHECK_CLAIMS": {"aud": "aud", "iss": "iss"}}
+    )
+    middleware = authorization_middleware(_ok_view)
+    request = create_request(tokendata_two_scopes_aud_iss, "4")
+    middleware(request)
+    assert request.is_authorized_for("scope1", "scope2")
+
+
+def test_jwks_from_url_entra_error(requests_mock):
+    """Verify that loading keyset from entra url raises an error when aud and iss claims are not set"""
+
+    jwks_url = "https://login.microsoftonline.com/get.your.jwks.here/discovery/keys"
+    requests_mock.get(jwks_url, text=json.dumps(JWKS1))
+    with pytest.raises(config.AuthzConfigurationError) as excinfo:
+        reload_settings({"JWKS": None, "JWKS_URL": jwks_url})
+    assert "When using Microsoft Entra ID" in str(excinfo.value)
+
+
+def test_jwks_from_url_list(requests_mock, tokendata_two_scopes_aud_iss):
+    """Verify that loading keyset from url list (with Keycloak and Entra keysets) works, by checking that is_authorized_for
+    method correctly evaluates that user has the scopes mentioned in the token data.
+    """
+    kc_jwks_url = "https://get.your.jwks.here/protocol/openid-connect/certs"
+    entra_jwks_url = "https://login.microsoftonline.com/get.your.jwks.here/discovery/keys"
+    requests_mock.get(kc_jwks_url, text=json.dumps(JWKS1))
+    requests_mock.get(entra_jwks_url, text=json.dumps(JWKS1))
+    reload_settings(
+        {
+            "JWKS": None,
+            "JWKS_URLS": [kc_jwks_url, entra_jwks_url],
+            "CHECK_CLAIMS": {"aud": "aud", "iss": "iss"},
+        }
+    )
+    middleware = authorization_middleware(_ok_view)
+    request = create_request(tokendata_two_scopes_aud_iss, "4")
     middleware(request)
     assert request.is_authorized_for("scope1", "scope2")
 
@@ -350,13 +416,39 @@ def test_keycloak_token(middleware, tokendata_keycloak_two_scopes):
     assert request.get_token_scopes == {"SCOPE/1", "SCOPE/2"}
 
 
-def test_entra_id_token(middleware, tokendata_entra_id_two_scopes):
+def test_keycloak_token_check_claims(middleware, tokendata_keycloak_two_scopes):
+    testsettings = TESTSETTINGS.copy()
+    testsettings["CHECK_CLAIMS"] = {"aud": "aud", "iss": "https://iam.amsterdam.nl"}
+    reload_settings(testsettings)
+    request = create_request(tokendata_keycloak_two_scopes, "1")
+    middleware(request)
+
+    assert request.get_token_subject == "test@tester.nl"
+    assert request.get_token_scopes == {"SCOPE/1", "SCOPE/2"}
+
+
+def test_entra_id_token_aud_iss(middleware, tokendata_entra_id_two_scopes):
+    testsettings = TESTSETTINGS.copy()
+    testsettings["CHECK_CLAIMS"] = {"aud": "aud", "iss": "https://sts.windows.net"}
+    reload_settings(testsettings)
     request = create_request(tokendata_entra_id_two_scopes, "1")
     middleware(request)
 
     assert request.get_token_subject == "test@tester.nl"
     assert request.get_token_scopes == {"test-scope-1", "test-scope-2"}
     assert request.get_token_claims["appid"] == "client_id"
+
+
+def test_entra_id_token_no_aud(middleware, tokendata_entra_id_two_scopes):
+    testsettings = TESTSETTINGS.copy()
+    testsettings["CHECK_CLAIMS"] = {"aud": "aud", "iss": "https://sts.windows.net"}
+    reload_settings(testsettings)
+
+    # Remove aud claim
+    tokendata_entra_id_two_scopes.pop("aud", None)
+    request = create_request(tokendata_entra_id_two_scopes, "1")
+    response = middleware(request)
+    assert response.status_code == 401
 
 
 @pytest.mark.xfail(reason="AD Token not supported for now")
@@ -492,6 +584,16 @@ def test_check_correct_issuer_expired(tokendata_issuer_expired):
     """
     testsettings = TESTSETTINGS.copy()
     testsettings["CHECK_CLAIMS"] = {"iss": "FOOBAR"}
+    reload_settings(testsettings)
+    middleware = authorization_middleware(_ok_view)
+    request = create_request(tokendata_issuer_expired, "4")
+    response = middleware(request)
+    assert response.status_code == 401
+
+
+def test_check_iss_aud_present_for_entra(tokendata_issuer_expired):
+    """ """
+    testsettings = TESTSETTINGS.copy()
     reload_settings(testsettings)
     middleware = authorization_middleware(_ok_view)
     request = create_request(tokendata_issuer_expired, "4")


### PR DESCRIPTION
De middleware kan nu apps handlen die zowel Keycloak als Entra ID hebben geconfigureerd (zoals de DSO-API)

Aanpassingen die hiervoor nodig waren:
- De setting JWKS_URLS is ook toegestaan (bevat meerdere URLS naar jw keysets)
- Als de JWKS_URLS een keyset naar Entra ID bevat, moeten `iss` en `aud` in de CHECK_CLAIMS variabele worden meegegeven
- De  `iss` en `aud` claims in een Entra token worden gecheckt met de  `iss` en `aud` waarden in de applicatie waar het token voor gebruikt wordt. Dit is niet nodig voor Keycloak, dus daarbij wordt deze check overgeslagen
- Testjes toegevoegd, ook extra voor de aanwezigheid van `iss` en `aud` claims in Entra tokens