### PR TITLE
Make publish-to-pypi action consistent with schema-tools

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -6,11 +6,12 @@ permissions:
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+'
-      - '[0-9]+.[0-9]+.*'
+      - 'v[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.*'
 
 jobs:
   build:
+    if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/authorization_django-v')}}
     name: Build distribution
     runs-on: ubuntu-latest
 
@@ -31,6 +32,7 @@ jobs:
         path: dist/
 
   publish-to-pypi:
+    if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/authorization_django-v')}}
     name: Upload to PyPI
     needs:
       - build

--- a/README.md
+++ b/README.md
@@ -167,13 +167,13 @@ Doing a release
 
 (This is for authorization_django developers.)
 
-We use GitHub pull requests. If your PR should produce a new release of authorization_django, make sure one of the commit increments the version number in setup.cfg appropriately. Then,
+We use GitHub pull requests. If your PR should produce a new release of authorization_django, make sure one of the commits 1) increments the version number in setup.cfg appropriately and 2) adds a description of the release to the changelog below in this README. Then,
 
-* Merge the commit in GitHub, after review;
-* Pull the code from GitHub and merge it into the master branch: `git checkout main && git fetch origin && git merge --ff-only origin/main`
-* Tag the release `vX.Y.Z` with `git tag -a vX.Y.Z -m "Bump to vX.Y.Z"`
-* Push the tag to GitHub with `git push origin --tags`
-* The `publish-to-pypi`-workflow will automatically publish the release
+1. Merge the commit in GitHub, after review;
+2. Pull the code from GitHub and merge it into the master branch: `git checkout main && git fetch origin && git merge --ff-only origin/main`
+3. Tag the release `vX.Y.Z` with `git tag -a vX.Y.Z -m "Bump to vX.Y.Z"`
+4. Push the tag to GitHub with `git push origin --tags`
+5. The `publish-to-pypi`-workflow will automatically publish the release
 
 
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,21 @@ Testing:
 make test
 ```
 
+Doing a release
+----------
+
+(This is for authorization_django developers.)
+
+We use GitHub pull requests. If your PR should produce a new release of authorization_django, make sure one of the commit increments the version number in setup.cfg appropriately. Then,
+
+* Merge the commit in GitHub, after review;
+* Pull the code from GitHub and merge it into the master branch: `git checkout main && git fetch origin && git merge --ff-only origin/main`
+* Tag the release `vX.Y.Z` with `git tag -a vX.Y.Z -m "Bump to vX.Y.Z"`
+* Push the tag to GitHub with `git push origin --tags`
+* The `publish-to-pypi`-workflow will automatically publish the release
+
+
+
 Changelog
 ---------
 - v1.8.0


### PR DESCRIPTION
* Add v-prefix to version tags
* Limit branches for version tag pushes
* Add how-to-release steps to README