### PR TITLE
Fix custom response

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ We use GitHub pull requests. If your PR should produce a new release of authoriz
 
 Changelog
 ---------
+- v2.0.1
+  * Fix allow custom responses and preserve original responses
 - v2.0.0
   * Allow for custom (JSON) response after raised exception instead of direct 4** response.
 - v1.8.0

--- a/authorization_django/exceptions.py
+++ b/authorization_django/exceptions.py
@@ -44,7 +44,7 @@ class InvalidTokenError(AuthorizationError):
         self,
         status_code=401,
         code="invalid_token",
-        msg="Unauthorized",
+        msg="Unauthorized. Invalid token.",
         www_authenticate='Bearer realm="datapunt", error="invalid_token"',
     ):
         super().__init__(status_code, code, msg, www_authenticate)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 with open("README.md", encoding="utf-8") as f:
     long_description = f.read()
 
-version = "2.0.0"
+version = "2.0.1"
 packages = [
     "authorization_django",
     "authorization_django.extensions",

--- a/tests/test_authorization_django.py
+++ b/tests/test_authorization_django.py
@@ -14,8 +14,7 @@ from django.test import RequestFactory
 from jwcrypto.jwt import JWT
 
 from authorization_django import authorization_middleware, config, jwks
-from authorization_django.exceptions import AuthorizationError, InsufficientScopeError
-from authorization_django.middleware import AuthorizationMiddleware
+from authorization_django.exceptions import AuthorizationError
 
 JWKS1 = {
     "keys": [
@@ -804,15 +803,17 @@ def test_protected_route_overruled_error():
 
 
 def test_invalid_request_request_type(middleware, tokendata_expired):
-    """ Assert a json response is returned when settings the accept header"""
+    """Assert a json response is returned when settings the accept header"""
     request = create_request(tokendata_expired, "4")
     request.META["HTTP_ACCEPT"] = "application/json"
     response = middleware(request)
     assert response.status_code == 401
     assert "WWW-Authenticate" in response
     assert "expired_token" in response["WWW-Authenticate"]
-    assert (response.content ==
-            b'{"error": "expired_token", "message": "Unauthorized. Token expired."}')
+    assert (
+        response.content
+        == b'{"error": "expired_token", "message": "Unauthorized. Token expired."}'
+    )
 
 
 def test_custom_exception(middleware):


### PR DESCRIPTION
Make sure the original response is still returned when upstream configuration is not changed and fix allowing a custom handler to create a custom response.