### PR TITLE
Add account_id to requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ We use GitHub pull requests. If your PR should produce a new release of authoriz
 
 Changelog
 ---------
-
+* v2.1.0
+  * Add account_id from the user to the request.
 * v2.0.4
   * Bump packages.
 * v2.0.3

--- a/authorization_django/middleware.py
+++ b/authorization_django/middleware.py
@@ -128,8 +128,24 @@ class AuthorizationMiddleware:
         sub = claims["sub"]
         scopes = claims["scopes"]
         claims = claims["claims"]
+        account_id = self._get_account_id(claims, sub)
         token_signature = raw_jwt.split(".")[2]
-        return scopes, token_signature, sub, claims
+        return scopes, token_signature, sub, claims, account_id
+
+    def _get_account_id(self, claims, sub) -> str:
+        """Extract user email / system app id from whoever made the request"""
+
+        account_id = None
+        if "email" in claims:  # User email in Keycloak tokens
+            account_id = claims["email"]
+        elif "upn" in claims:  # User email in Entra ID tokens
+            account_id = claims["upn"]
+        elif "appid" in claims:  # Appid for Entra ID system accounts
+            account_id = claims["appid"]
+        # If none of the above, fall back to token subject
+        else:
+            account_id = sub
+        return account_id
 
     def _decode_token(self, raw_jwt):
         settings = get_settings()
@@ -260,12 +276,15 @@ class AuthorizationMiddleware:
         token_signature = ""
         subject = None
         claims = None
+        account_id = None
 
         x_unique_id = request.headers.get("x-unique-id")
         authz_header = request.headers.get("authorization")
         try:
             if authz_header:
-                scopes, token_signature, subject, claims = self.parse_token(authz_header)
+                scopes, token_signature, subject, claims, account_id = self.parse_token(
+                    authz_header
+                )
 
             authz_func = self.authorize_function(scopes, token_signature, x_unique_id)
             self.handle_scope(authz_func, request)
@@ -276,6 +295,7 @@ class AuthorizationMiddleware:
         request.get_token_subject = subject
         request.get_token_scopes = scopes
         request.get_token_claims = claims
+        request.account_id = account_id
         return self.get_response(request)
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 with open("README.md", encoding="utf-8") as f:
     long_description = f.read()
 
-version = "2.0.4"
+version = "2.1.0"
 packages = [
     "authorization_django",
     "authorization_django.extensions",

--- a/tests/test_authorization_django.py
+++ b/tests/test_authorization_django.py
@@ -197,6 +197,17 @@ def tokendata_two_scopes():
 
 
 @pytest.fixture
+def tokendata_account_id():
+    now = int(time.time())
+    return {
+        "iat": now,
+        "exp": now + 30,
+        "scopes": ["scope1", "scope2"],
+        "sub": "ABcD12_Ghi3K",
+    }
+
+
+@pytest.fixture
 def tokendata_two_scopes_aud_iss():
     now = int(time.time())
     return {
@@ -496,6 +507,24 @@ def test_get_token_claims(middleware, tokendata_two_scopes):
     request = create_request(tokendata_two_scopes, "4")
     middleware(request)
     assert request.get_token_claims == tokendata_two_scopes
+
+
+@pytest.mark.parametrize(
+    "name, value, result",
+    [
+        pytest.param(None, None, "ABcD12_Ghi3K", id="sub"),
+        pytest.param("email", "test_email@tester.nl", "test_email@tester.nl", id="email"),
+        pytest.param("upn", "test_upn@tester.nl", "test_upn@tester.nl", id="upn"),
+        pytest.param("appid", "APP-XXX-ID", "APP-XXX-ID", id="appid"),
+    ],
+)
+def test_get_token_account_id(middleware, tokendata_account_id, name, value, result):
+    if name:
+        tokendata_account_id[name] = value
+
+    request = create_request(tokendata_account_id, "4")
+    middleware(request)
+    assert request.account_id == result
 
 
 def test_invalid_token_requests(middleware, tokendata_missing_scopes, tokendata_two_scopes):


### PR DESCRIPTION
Select the correct claim (this is different for Keycloak vs.Entra) to extract the email address of the user who made the request. This is then added to the request as 'account_id' property. For system accounts, select the app id. If none of the above are present, extract the 'sub' claim as account_id

Note: Er wordt in de tests nog aangenomen dat de `sub` claim een e-mail adres bevat, maar zowel Keycloak als Entra tokens is het een token. De `sub` claim wordt wel aangeraden om een user mee te identificeren: 

https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference#use-claims-to-reliably-identify-a-user

Maar dat is out of scope voor deze PR lijkt me?